### PR TITLE
Fix disappearing fonts on navbar Languages click

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -6,6 +6,7 @@
         <meta charset="utf-8"/>
         <link href="../css/style.css" rel="stylesheet" type="text/css"/>
         <link href="../../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
+        <link rel="preload" href="../assets/NotoColorEmoji.ttf" as="font" type="font/tff" crossorigin>
         <script src="https://kit.fontawesome.com/7add23c1ae.js" crossorigin="anonymous"></script>
         <link rel="icon" href="../assets/favicon.ico">
         <meta name="description" content="A website that lets you take turns controlling online virtual machines with complete strangers!"/>


### PR DESCRIPTION
Fonts disappear for a bit when the Languages dropdown in the navbar is clicked. This is due to the NotoEmojiColor font (10MB) being requested on click. This change preloads the font and the rendering issue is gone.