### PR TITLE
Update pt-br.json to meet en-us format

### DIFF
--- a/static/lang/pt-br.json
+++ b/static/lang/pt-br.json
@@ -1,4 +1,3 @@
-
 {
 	"languageName": "Português (Brasil)",
 	"translatedLanguageName": "Brazilian Portuguese",
@@ -12,13 +11,13 @@
 		"kGeneric_Ok": "OK",
 		"kGeneric_Cancel": "Cancelar",
 		"kGeneric_Send": "Enviar",
-		"kGeneric_Understood": "Eu entendi",
+		"kGeneric_Understood": "Entendido",
 		"kGeneric_Username": "Nome de usuário",
 		"kGeneric_Password": "Senha",
 		"kGeneric_Login": "Fazer login",
 		"kGeneric_Register": "Registrar",
 		"kGeneric_EMail": "E-Mail",
-		"kGeneric_DateOfBirth": "Data de Nascimento ",
+		"kGeneric_DateOfBirth": "Data de Nascimento",
 		"kGeneric_VerificationCode": "Código de verificação",
 		"kGeneric_Verify": "Verificar",
 		"kGeneric_Update": "Salvar",
@@ -27,7 +26,7 @@
 		"kWelcomeModal_Header": "Bem vindo a CollabVM",
 		"kWelcomeModal_Body": "<p>Antes de continuar, familiarize-se com nossas regras:</p> <h3>R1. Não infrinja a lei.</h3> Não use o CollabVM ou a rede do CollabVM para violar leis federais dos Estados Unidos, lei do estado de Nova York ou lei internacional. Se o CollabVM tomar conhecimento de que um crime foi cometido por meio de seu serviço, você será imediatamente banido e suas atividades poderão ser denunciadas às autoridades, se necessário.<br><br>O CollabVM é. é obrigado por lei a notificar as agências de aplicação da lei se tomar conhecimento da presença de pornografia infantil ou sendo transmitida através de sua rede.<br><br>A COPPA também é aplicada, por favor, não use o CollabVM se você tiver menos de idade 13 anos. <h3>R2. Não é permitido executar ferramentas DoS/DDoS.</h3> Não use CollabVM para DoS/DDoS em um indivíduo, empresa, ou qualquer outra pessoa.</h3>R3. h3> Não envie spam em e-mails usando este serviço ou envie spam em geral. <h3>R4 Não abuse nenhum exploit (vulnerabilidade).</h3> Não abuse nenhum exploit, além disso, se você vir alguém abusando exploits ou precisar denunciar um, entre em contato comigo em: computernewbab@gmail.com <h3>R5. Não se faça passar por outros usuários.</h3> Não se faça passar por outros membros do CollabVM. Se for pego, você será temporariamente desconectado e banido, se necessário. <h3>T6. Um voto por pessoa.</h3> Não use nenhum método ou ferramenta para contornar a restrição de voto. Apenas um voto por pessoa é permitido, não importa o que aconteça. Qualquer pessoa que for flagrada fazendo isso será banida. <h3>T7. Sem ferramentas de administração remota.</h3> Não use nenhuma ferramenta de administração remota (ex: DarkComet, NanoCore, Anydesk, TeamViewer, Orcus, etc.) <h3>R8. Não é possível ignorar o CollabNet.</h3> Não tente ignorar o bloqueio fornecido pelo CollabNet, especialmente se ele estiver sendo usado para quebrar a Regra 1, Regra 2 ou Regra 7 (ou executar coisas estúpidas e usadas demais). <h3>R9. Não é permitido realizar ações destrutivas constantemente.</h3> Qualquer usuário não pode destruir a VM (tornando-a inutilizável constantemente), instalar/reinstalar o sistema operacional (exceto em VM7 ou VM8) ou executar bots que façam isso. Isso inclui bots que enviam spam para grandes quantidades de entradas de teclado/mouse (ou kitting). <h3>R10. Sem criptografia</h3> A tentativa de minerar criptomoedas nas VMs resultará em uma expulsão e, em seguida, em um banimento permanente se você continuar tentando. Além disso, não é como se você fosse ganhar dinheiro com isso. <h3>Aviso NSFW</h3> Observe que o conteúdo NSFW é permitido em nossa VM anarquia (VM0b0t) e é visualizado regularmente. Além disso, embora façamos um grande esforço para manter o NSFW fora das VMs principais, as pessoas ocasionalmente irão passar despercebidas.",
 
-		"kSiteButtons_Home": "Ínicio",
+		"kSiteButtons_Home": "Início",
 		"kSiteButtons_FAQ": "FAQ",
 		"kSiteButtons_Rules": "Regras",
 		"kSiteButtons_DarkMode": "Modo Escuro",
@@ -36,12 +35,13 @@
 
 		"kVM_UsersOnlineText": "Usuários online:",
 
-		"kVM_TurnTimeTimer": "Sua vez expira em  {0} segundos.",
+		"kVM_TurnTimeTimer": "Sua vez expira em {0} segundos.",
 		"kVM_WaitingTurnTimer": "Esperando sua vez em {0} segundos.",
 		"kVM_VoteCooldownTimer": "Aguarde {0} segundos antes de iniciar outra votação.",
 
 		"kVM_VoteForResetTitle": "Deseja redefinir a VM?",
-		"kVM_VoteForResetTimer": "Voto acaba em {0} segundos",		
+		"kVM_VoteForResetTimer": "Voto acaba em {0} segundos",
+		
 		"kVMButtons_TakeTurn": "Tomar turno",
 		"kVMButtons_EndTurn": "Finalizar turno",
 		"kVMButtons_ChangeUsername": "Mudar nome de usuário",
@@ -60,6 +60,8 @@
 		"kAdminVMButtons_ClearTurnQueue": "Limpar fila de turno",
 		"kAdminVMButtons_BypassTurn": "Ignorar Turno",
 		"kAdminVMButtons_IndefiniteTurn": "Turno infinito",
+		"kAdminVMButtons_GhostTurnOn": "Turno Fantasma (Ativar)",
+		"kAdminVMButtons_GhostTurnOff": "Turno Fantasma (Desativar)",
 
 		"kAdminVMButtons_Ban": "Banir",
 		"kAdminVMButtons_Kick": "Expulsar",


### PR DESCRIPTION
Fixed up a grammar mistake, changed the Understood to "Entendido", which is more proper to have a direct translation from the US lang, and added the "Ghost Turn" option, even though there aren't any Brazilian admins, at least it is updated :)

Also gotta mention some changes to end up with the same amount of text lines as the EN-US language, as its easier to other translators to add new strings.